### PR TITLE
Support exit handler for pool's actors

### DIFF
--- a/lib/celluloid/supervision/container/behavior/pool.rb
+++ b/lib/celluloid/supervision/container/behavior/pool.rb
@@ -31,7 +31,7 @@ module Celluloid
       end
 
       class Instance
-        attr_accessor :pool, :pool_size
+        attr_accessor :pool, :pool_size, :exit_handler
       end
 
       class << self
@@ -49,7 +49,7 @@ module Celluloid
         class << self
           def pooling_options(config={},mixins={})
             combined = { :type => Celluloid::Supervision::Container::Pool }.merge(config).merge(mixins)
-            combined[:args] = [[:block, :actors, :size, :args].inject({}) { |e,p| e[p] = combined.delete(p) if combined[p]; e }]
+            combined[:args] = [[:block, :actors, :size, :args, :exit_handler].inject({}) { |e,p| e[p] = combined.delete(p) if combined[p]; e }]
             combined
           end
         end
@@ -60,12 +60,13 @@ module Celluloid
           @supervisor = Container::Pool
           @method = "pool_link"
           @pool = true
-          @pool_size = @cofiguration[:size]
+          @pool_size = @configuration[:size]
+          @exit_handler = @configuration[:exit_handler]
           @configuration
         end
       end
 
-      
+
     end
   end
 end

--- a/lib/celluloid/supervision/container/pool.rb
+++ b/lib/celluloid/supervision/container/pool.rb
@@ -21,6 +21,7 @@ module Celluloid
 
           @size = options[:size] || [Celluloid.cores || 2, 2].max
           @args = options[:args] ? Array(options[:args]) : []
+          @exit_handler = options[:exit_handler]
 
           # Do this last since it can suspend and/or crash
           @idle = @size.times.map { __spawn_actor__ }
@@ -121,7 +122,7 @@ module Celluloid
         def __busy
           @busy
         end
-        
+
         def __idle
           @idle
         end
@@ -166,6 +167,9 @@ module Celluloid
             @idle.delete actor
             @actors.delete actor
           }
+
+          @exit_handler.call(actor, reason) if @exit_handler
+
           return unless reason
 
           @idle << __spawn_actor__


### PR DESCRIPTION
This is my tentative fix to address https://github.com/celluloid/celluloid-pool/issues/8. It also fixes a small typo with `pool_size` (not really sure where else that is used).